### PR TITLE
fix(cli): in 'generate' and 'serve' command, 'output' flag is not required by default

### DIFF
--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -1,13 +1,13 @@
 import open from 'open';
 import { Argv } from 'yargs';
-import { transform } from '../utils';
+import { createDestStatReportPath, transform } from '../utils';
 
 export default function (yargs: Argv): Argv {
   return yargs.command(
-    'generate [input] [output]',
+    'generate [input]',
     `Generate HTML report from JSON-stats
 Examples:
-Single stats: generate path/to/stats.json path/to/report.html
+Single stats: generate path/to/stats.json --output path/to/report.html
 Multiple stats: generate --input path/to/stats-1.json path/to/stats-2.json --output path/to/report.html`,
     (yargs) => {
       return yargs
@@ -26,15 +26,17 @@ Multiple stats: generate --input path/to/stats-1.json path/to/stats-2.json --out
           alias: 'o',
         })
         .array('input')
-        .demandOption(['input', 'output']);
+        .demandOption('input');
     },
     async (argv) => {
-      console.log(`Generating Statoscope report to ${argv.output} ...`);
-      await transform(argv.input, argv.output);
+      const destReportPath = createDestStatReportPath(argv.input, argv.output);
+
+      console.log(`Generating Statoscope report to ${destReportPath} ...`);
+      await transform(argv.input, destReportPath);
       console.log(`Statoscope report saved to ${argv.output}`);
 
       if (argv.open) {
-        open(argv.output);
+        open(destReportPath);
       }
     }
   );

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import http from 'http';
 import { Argv } from 'yargs';
 import open from 'open';
-import { transform } from '../utils';
+import { createDestStatReportPath, transform } from '../utils';
 
 export default function (yargs: Argv): Argv {
   return yargs.command(
@@ -36,7 +36,8 @@ Multiple stats: serve --input path/to/stats-1.json path/to/stats-2.json
     },
     async (argv) => {
       console.log(`Generating Statoscope report...`);
-      const reportPath = await transform(argv.input);
+      const destReportPath = createDestStatReportPath(argv.input);
+      const reportPath = await transform(argv.input, destReportPath);
       console.log(`Statoscope report generated`);
 
       http

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -11,10 +11,7 @@ import normalizeCompilation from '@statoscope/webpack-model/dist/normalizeCompil
 import { Webpack } from '@statoscope/webpack-model/webpack';
 import Compilation = Webpack.Compilation;
 
-export async function transform(from: string[], to?: string): Promise<string> {
-  const id = path.basename(from[0], '.json');
-  const reportPath =
-    to || path.join(os.tmpdir(), `statoscope-report-${id}-${Date.now()}.html`);
+export async function transform(from: string[], to: string): Promise<string> {
   const normalizedFrom: FromItem[] = [];
 
   for (const item of from) {
@@ -38,6 +35,11 @@ export async function transform(from: string[], to?: string): Promise<string> {
       },
     },
     normalizedFrom,
-    reportPath
+    to
   );
 }
+
+export const createDestStatReportPath = (from: string[], to?: string): string => {
+  const id = path.basename(from[0], '.json');
+  return to || path.join(os.tmpdir(), `statoscope-report-${id}-${Date.now()}.html`);
+};


### PR DESCRIPTION
Hello, I was solving this  [issue](https://github.com/statoscope/statoscope/issues/70)

What should I do with tests? 