### PR TITLE
chore(types): переношу тайпинги в devDeps

### DIFF
--- a/packages/webpack-model/package-lock.json
+++ b/packages/webpack-model/package-lock.json
@@ -6,15 +6,15 @@
 	"packages": {
 		"": {
 			"name": "@statoscope/webpack-model",
-			"version": "5.14.1",
+			"version": "5.20.0",
 			"license": "MIT",
 			"dependencies": {
-				"@types/md5": "^2.3.0",
-				"@types/webpack": "^5.0.0",
 				"ajv": "^8.6.3",
 				"md5": "^2.3.0"
 			},
 			"devDependencies": {
+				"@types/md5": "^2.3.0",
+				"@types/webpack": "^5.0.0",
 				"flatted": "^3.1.1"
 			}
 		},

--- a/packages/webpack-model/package.json
+++ b/packages/webpack-model/package.json
@@ -26,12 +26,12 @@
     "@statoscope/stats-extension-package-info": "5.19.3",
     "@statoscope/stats-extension-stats-validation-result": "5.19.0",
     "@statoscope/types": "5.14.1",
-    "@types/md5": "^2.3.0",
-    "@types/webpack": "^5.0.0",
     "ajv": "^8.6.3",
     "md5": "^2.3.0"
   },
   "devDependencies": {
+    "@types/md5": "^2.3.0",
+    "@types/webpack": "^5.0.0",
     "flatted": "^3.1.1"
   }
 }

--- a/packages/webpack-plugin/package-lock.json
+++ b/packages/webpack-plugin/package-lock.json
@@ -10,9 +10,11 @@
 			"license": "MIT",
 			"dependencies": {
 				"@discoveryjs/json-ext": "^0.5.5",
-				"@types/node": "^12.20.15",
-				"@types/webpack": "^5.0.0",
 				"open": "^8.2.1"
+			},
+			"devDependencies": {
+				"@types/node": "^12.20.15",
+				"@types/webpack": "^5.0.0"
 			},
 			"peerDependencies": {
 				"webpack": "^4.0.0 || ^5.0.0"

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -28,9 +28,11 @@
     "@statoscope/webpack-stats-extension-compressed": "5.20.0",
     "@statoscope/webpack-stats-extension-package-info": "5.20.0",
     "@statoscope/webpack-ui": "5.20.0",
-    "@types/node": "^12.20.15",
-    "@types/webpack": "^5.0.0",
     "open": "^8.2.1"
+  },
+  "devDependencies": {
+    "@types/node": "^12.20.15",
+    "@types/webpack": "^5.0.0"
   },
   "peerDependencies": {
     "webpack": "^4.0.0 || ^5.0.0"

--- a/packages/webpack-stats-extension-compressed/package-lock.json
+++ b/packages/webpack-stats-extension-compressed/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "@statoscope/webpack-stats-extension-compressed",
 			"version": "5.14.1",
 			"license": "MIT",
-			"dependencies": {
+			"devDependencies": {
 				"@types/webpack": "^5.0.0"
 			},
 			"peerDependencies": {

--- a/packages/webpack-stats-extension-compressed/package.json
+++ b/packages/webpack-stats-extension-compressed/package.json
@@ -20,7 +20,9 @@
   "dependencies": {
     "@statoscope/stats": "5.14.1",
     "@statoscope/stats-extension-compressed": "5.19.0",
-    "@statoscope/webpack-model": "5.20.0",
+    "@statoscope/webpack-model": "5.20.0"
+  },
+  "devDependencies": {
     "@types/webpack": "^5.0.0"
   },
   "peerDependencies": {

--- a/packages/webpack-stats-extension-package-info/package-lock.json
+++ b/packages/webpack-stats-extension-package-info/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "@statoscope/webpack-stats-extension-package-info",
 			"version": "5.14.1",
 			"license": "MIT",
-			"dependencies": {
+			"devDependencies": {
 				"@types/webpack": "^5.0.0"
 			},
 			"peerDependencies": {

--- a/packages/webpack-stats-extension-package-info/package.json
+++ b/packages/webpack-stats-extension-package-info/package.json
@@ -20,7 +20,9 @@
   "dependencies": {
     "@statoscope/stats": "5.14.1",
     "@statoscope/stats-extension-package-info": "5.19.3",
-    "@statoscope/webpack-model": "5.20.0",
+    "@statoscope/webpack-model": "5.20.0"
+  },
+  "devDependencies": {
     "@types/webpack": "^5.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Так как @types/webpack не в devDeps, то в проектах с webpack@4 прилетает webpack@5. Это иногда влечёт некорректный резолвинг пакетов.

Заодно убрал все @types по проекту в devDeps