### PR TITLE
fix(webpack-model): ignore null chunk files

### DIFF
--- a/packages/webpack-model/src/handleCompilation.ts
+++ b/packages/webpack-model/src/handleCompilation.ts
@@ -423,6 +423,7 @@ function prepareChunk(chunk: Webpack.Chunk | null, context: ProcessingContext): 
 
   if (chunk.files) {
     normalizedChunk.files = chunk.files
+      .filter(Boolean) // to skip null files, issue #158
       .map((f) => context.rawIndexes.assets.get(typeof f === 'string' ? f : f.name))
       .filter(Boolean) as NormalizedAsset[];
   } else {


### PR DESCRIPTION
Addresses #158 

**Disclaimer:**
Didn't check where those `null` files are coming from and if those are supposed to be there in the first place.
Also not sure if any other related code might have to be updated in a similar fashion - quick search didn't reveal any.
