### PR TITLE
chore(typo): Fix typo in "Instance version conflict"-error

### DIFF
--- a/packages/stats-extension-package-info/src/generator.ts
+++ b/packages/stats-extension-package-info/src/generator.ts
@@ -87,7 +87,7 @@ export default class Generator {
     } else {
       if (resolvedInstance.info.version !== info.version) {
         throw new Error(
-          `[Instnce version conflict] ${instance} old ${resolvedInstance.info.version} new ${info.version}`
+          `[Instance version conflict] ${instance} old ${resolvedInstance.info.version} new ${info.version}`
         );
       }
     }


### PR DESCRIPTION
Just a typo in error message.