### PR TITLE
peft(webpack-model): cache partsLabels in handleModule

### DIFF
--- a/packages/webpack-model/src/modules-to-foam-tree.ts
+++ b/packages/webpack-model/src/modules-to-foam-tree.ts
@@ -50,8 +50,8 @@ function handleModule(
     return;
   }
 
-  const parts: NodeData[] = resource.split(/[/\\]/).map((label) => ({ label }));
-  const partsLabels = parts.map((part) => part.label);
+  const partsLabels = resource.split(/[/\\]/);
+  const parts: NodeData[] = partsLabels.map((label) => ({ label }));
   let currentPackage = null;
 
   for (const [i, part] of parts.entries()) {

--- a/packages/webpack-model/src/modules-to-foam-tree.ts
+++ b/packages/webpack-model/src/modules-to-foam-tree.ts
@@ -75,9 +75,7 @@ function handleModule(
               }
             : undefined,
           params: {
-            instance: partsLabels
-              .slice(0, i + 1)
-              .join('/'),
+            instance: partsLabels.slice(0, i + 1).join('/'),
           },
         };
         currentPackage = null;

--- a/packages/webpack-model/src/modules-to-foam-tree.ts
+++ b/packages/webpack-model/src/modules-to-foam-tree.ts
@@ -51,6 +51,7 @@ function handleModule(
   }
 
   const parts: NodeData[] = resource.split(/[/\\]/).map((label) => ({ label }));
+  const partsLabels = parts.map((part) => part.label);
   let currentPackage = null;
 
   for (const [i, part] of parts.entries()) {
@@ -74,8 +75,7 @@ function handleModule(
               }
             : undefined,
           params: {
-            instance: parts
-              .map((part) => part.label)
+            instance: partsLabels
               .slice(0, i + 1)
               .join('/'),
           },


### PR DESCRIPTION
I cached creating `partsLabels` to avoid new `map` each iteration.